### PR TITLE
Do not use iostat's first report.

### DIFF
--- a/files/disk_queue_size.sh
+++ b/files/disk_queue_size.sh
@@ -2,7 +2,7 @@
 
 source /home/centos/instance_info
 
-command=`iostat -x -d /dev/xvda | awk '/xvda/ { print $9}'`
+command=`iostat -x 1 -d /dev/xvda count 3 | awk 'NR==7 {print $9}'`
 
 per_host_options="--namespace AWS/EC2 --region us-west-2 --dimensions TestId=$test_id,Instance=$instance"
 


### PR DESCRIPTION
https://serverfault.com/questions/620727/iostat-reporting-low-r-s-on-first-line-for-specific-disk-expected-r-s-on-all-fo

Signed-off-by: Yvonne Lam <yvonne@chef.io>